### PR TITLE
fix: initx11_hash -> initxevan_hash

### DIFF
--- a/xevanmodule.c
+++ b/xevanmodule.c
@@ -51,7 +51,7 @@ PyMODINIT_FUNC PyInit_xevan_hash(void) {
 
 #else
 
-PyMODINIT_FUNC initx11_hash(void) {
+PyMODINIT_FUNC initxevan_hash(void) {
     (void) Py_InitModule("xevan_hash", xevanMethods);
 }
 #endif


### PR DESCRIPTION
Without this it breaks in py2 with `ImportError: dynamic module does not define init function (initxevan_hash)`